### PR TITLE
Add REST API endpoint for display data retrieval

### DIFF
--- a/Tribler/Core/Modules/restapi/display_endpoint.py
+++ b/Tribler/Core/Modules/restapi/display_endpoint.py
@@ -1,0 +1,95 @@
+"""
+Handle HTTP requests for the trust display, whilst validating the arguments and using them in the query.
+"""
+import json
+
+from twisted.web import http, resource
+
+
+class DisplayEndpoint(resource.Resource):
+    """
+    Handle HTTP requests for the trust display.
+    """
+
+    def __init__(self, session):
+        """
+        Initialize the DisplayEndpoint and make a session an attribute from the instance.
+
+        :param session: the Session object where the aggregated data can be retrieved from
+        """
+        resource.Resource.__init__(self)
+        self.session = session
+
+    @staticmethod
+    def return_400(request, message="your request seems to be wrong"):
+        """
+        Return a HTTP Code 400 with the given message.
+
+        :param request: the request which has to be changed
+        :param message: the error message which is used in the JSON string
+        :return: the error message formatted in JSON
+        """
+        request.setResponseCode(http.BAD_REQUEST)
+        return json.dumps({"error": message})
+
+    def render_GET(self, request):
+        """
+        Process the GET request which retrieves the information used by the GUI Trust Display window.
+
+        .. http:get:: /display?focus_node=(string: public key)&neighbor_level=(int: neighbor_level)
+
+        A GET request to this endpoint returns the data from the multichain. This data is retrieved from the multichain
+        database and will be focused around the given focus node. The neighbor_level parameter specifies which nodes
+        are taken into consideration (e.g. a neighbor_level of 2 indicates that only the focus node, it's neighbors
+        and the neighbors of those neighbors are taken into consideration). Please note that the neighbor_level
+        parameter is optional; if the parameter is not set, a neighbor_level of 1 is assumed.
+
+        The returned data will be in such format that the GUI component which visualizes this data can easily use it.
+        Although this data might not seem as formatted in a useful way to the human eye, this is done to accommodate as
+        little parsing effort at the GUI side.
+
+            **Example request**:
+
+            .. sourcecode:: none
+
+                curl -X GET http://localhost:8085/display?focus_node=xyz
+
+            **Example response**:
+
+            .. sourcecode:: javascript
+
+                {
+                    "focus_node": "xyz",
+                    "neighbor_level: 1
+                    "nodes": [{
+                        "public_key": "xyz",
+                        "total_up": 12736457,
+                        "total_down": 1827364
+                    }, ...],
+                    "edges": [{
+                        "from": "xyz",
+                        "to": "xyz_n1",
+                        "size": 12384
+                    }, ...]
+                }
+
+        :param request: the HTTP GET request which specifies the focus node and optionally the neighbor level
+        :return: the node data formatted in JSON
+        """
+        if "focus_node" not in request.args:
+            return DisplayEndpoint.return_400(request, "focus_node parameter missing")
+
+        if len(request.args["focus_node"]) < 1 or len(request.args["focus_node"][0]) == 0:
+            return DisplayEndpoint.return_400(request, "focus_node parameter empty")
+
+        neighbor_level = 1
+        # Note that isdigit() checks if all chars are numbers, hence negative numbers are not possible to be set
+        if "neighbor_level" in request.args and len(request.args["neighbor_level"]) > 0 and \
+                request.args["neighbor_level"][0].isdigit():
+            neighbor_level = int(request.args["neighbor_level"][0])
+
+        # TODO: Remove dummy return and change to aggregated data calculation
+        return json.dumps({"focus_node": request.args["focus_node"][0],
+                           "neighbor_level": neighbor_level,
+                           "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0}],
+                           "edges": []})

--- a/Tribler/Core/Modules/restapi/root_endpoint.py
+++ b/Tribler/Core/Modules/restapi/root_endpoint.py
@@ -4,6 +4,7 @@ from Tribler.Core.Modules.restapi.channels.channels_endpoint import ChannelsEndp
 from Tribler.Core.Modules.restapi.channels.my_channel_endpoint import MyChannelEndpoint
 from Tribler.Core.Modules.restapi.create_torrent_endpoint import CreateTorrentEndpoint
 from Tribler.Core.Modules.restapi.debug_endpoint import DebugEndpoint
+from Tribler.Core.Modules.restapi.display_endpoint import DisplayEndpoint
 from Tribler.Core.Modules.restapi.downloads_endpoint import DownloadsEndpoint
 from Tribler.Core.Modules.restapi.events_endpoint import EventsEndpoint
 from Tribler.Core.Modules.restapi.multichain_endpoint import MultichainEndpoint
@@ -45,7 +46,7 @@ class RootEndpoint(resource.Resource):
                               "downloads": DownloadsEndpoint, "createtorrent": CreateTorrentEndpoint,
                               "torrents": TorrentsEndpoint, "debug": DebugEndpoint, "shutdown": ShutdownEndpoint,
                               "multichain": MultichainEndpoint, "statistics": StatisticsEndpoint,
-                              "torrentinfo": TorrentInfoEndpoint}
+                              "torrentinfo": TorrentInfoEndpoint, "display": DisplayEndpoint}
 
         for path, child_cls in child_handler_dict.iteritems():
             self.putChild(path, child_cls(self.session))

--- a/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
@@ -1,0 +1,47 @@
+from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
+from Tribler.Test.twisted_thread import deferred
+
+
+class TestDisplayEndpoint(AbstractApiTest):
+    """
+    Test the DisplayEndpoint, the endpoint from which you can retrieve aggregated data from the multichain.
+    """
+
+    def setUpPreSession(self):
+        super(TestDisplayEndpoint, self).setUpPreSession()
+
+    @deferred(timeout=10)
+    def test_get_no_focus_node(self):
+        """
+        Test whether the API returns an Bad Request error if there is no focus node specified.
+        """
+        exp_message = {"error": "focus_node parameter missing"}
+        return self.do_request('display?neighbor_level=1', expected_code=400, expected_json=exp_message)
+
+    @deferred(timeout=10)
+    def test_get_empty_focus_node(self):
+        """
+        Test whether the API returns a Bad Request error if the focus node is empty.
+        """
+        exp_message = {"error": "focus_node parameter empty"}
+        return self.do_request('display?focus_node=&neighbor_level=1', expected_code=400, expected_json=exp_message)
+
+    @deferred(timeout=10)
+    def test_get_neighbor_level_string(self):
+        """
+        Test whether the API uses the default neighbor_level if the parameter is set to a string.
+        """
+        # TODO: The dummy data is now expected, make sure to rewrite test if actual implementation is used
+        exp_message = {"focus_node": "xyz", "neighbor_level": 1, "nodes": [{"public_key": "xyz", "total_up": 0,
+                                                                            "total_down": 0}], "edges": []}
+        return self.do_request('display?focus_node=xyz&neighbor_level=x', expected_code=200, expected_json=exp_message)
+
+    @deferred(timeout=10)
+    def test_get_neighbor_level_zero(self):
+        """
+        Test whether the API uses the actual neighbor_level if the parameter is set.
+        """
+        # TODO: The dummy data is now expected, make sure to rewrite test if actual implementation is used
+        exp_message = {"focus_node": "xyz", "neighbor_level": 0, "nodes": [{"public_key": "xyz", "total_up": 0,
+                                                                            "total_down": 0}], "edges": []}
+        return self.do_request('display?focus_node=xyz&neighbor_level=0', expected_code=200, expected_json=exp_message)


### PR DESCRIPTION
Implements issue #42 

In this PR, there is a new DisplayEndpoint class which provides a
HTTP API endpoint which can be used to retrieve the data necessary for
the Trust Display in the GUI. Moreover, this functionality is tested in
the test file.

**Please make sure to comment on the way the HTTP Request is now documented (i.e. whether you agree with this setup). This is documented in the docstring of the render_GET method.**