### PR TITLE
Add self to focus_node parameter of HTTP API

### DIFF
--- a/Tribler/Core/Modules/restapi/display_endpoint.py
+++ b/Tribler/Core/Modules/restapi/display_endpoint.py
@@ -1,9 +1,13 @@
 """
 Handle HTTP requests for the trust display, whilst validating the arguments and using them in the query.
 """
+from binascii import hexlify
 import json
 
 from twisted.web import http, resource
+
+from Tribler.Core.exceptions import OperationNotEnabledByConfigurationException
+from Tribler.community.multichain.community import MultiChainCommunity
 
 
 class DisplayEndpoint(resource.Resource):
@@ -21,16 +25,30 @@ class DisplayEndpoint(resource.Resource):
         self.session = session
 
     @staticmethod
-    def return_400(request, message="your request seems to be wrong"):
+    def return_error(request, status_code=http.BAD_REQUEST, message="your request seems to be wrong"):
         """
         Return a HTTP Code 400 with the given message.
 
         :param request: the request which has to be changed
+        :param status_code: the HTTP status code to be returned
         :param message: the error message which is used in the JSON string
         :return: the error message formatted in JSON
         """
-        request.setResponseCode(http.BAD_REQUEST)
+        request.setResponseCode(status_code)
         return json.dumps({"error": message})
+
+    def get_multi_chain_community(self):
+        """
+        Get the MultiChain community from the session.
+
+        :raise: OperationNotEnabledByConfigurationException if the MultiChain Community cannot be found
+        :return: the MultiChain community
+        """
+        if not self.session.lm.session.get_enable_multichain():
+            raise OperationNotEnabledByConfigurationException("multichain is not enabled")
+        for community in self.session.get_dispersy_instance().get_communities():
+            if isinstance(community, MultiChainCommunity):
+                return community
 
     def render_GET(self, request):
         """
@@ -41,8 +59,18 @@ class DisplayEndpoint(resource.Resource):
         A GET request to this endpoint returns the data from the multichain. This data is retrieved from the multichain
         database and will be focused around the given focus node. The neighbor_level parameter specifies which nodes
         are taken into consideration (e.g. a neighbor_level of 2 indicates that only the focus node, it's neighbors
-        and the neighbors of those neighbors are taken into consideration). Please note that the neighbor_level
-        parameter is optional; if the parameter is not set, a neighbor_level of 1 is assumed.
+        and the neighbors of those neighbors are taken into consideration).
+
+        Note: the parameters are handled as follows:
+        - focus_node
+            - Not given: HTTP 400
+            - Non-String value: HTTP 400
+            - "self": Multichain Community public key
+            - otherwise: Passed data, albeit a string
+        - neighbor_level
+            - Not given: 1
+            - Non-Integer value: 1
+            - otherwise: Passed data, albeit an integer
 
         The returned data will be in such format that the GUI component which visualizes this data can easily use it.
         Although this data might not seem as formatted in a useful way to the human eye, this is done to accommodate as
@@ -64,7 +92,8 @@ class DisplayEndpoint(resource.Resource):
                     "nodes": [{
                         "public_key": "xyz",
                         "total_up": 12736457,
-                        "total_down": 1827364
+                        "total_down": 1827364,
+                        "page_rank": 0.5
                     }, ...],
                     "edges": [{
                         "from": "xyz",
@@ -77,10 +106,23 @@ class DisplayEndpoint(resource.Resource):
         :return: the node data formatted in JSON
         """
         if "focus_node" not in request.args:
-            return DisplayEndpoint.return_400(request, "focus_node parameter missing")
+            return DisplayEndpoint.return_error(request, message="focus_node parameter missing")
 
         if len(request.args["focus_node"]) < 1 or len(request.args["focus_node"][0]) == 0:
-            return DisplayEndpoint.return_400(request, "focus_node parameter empty")
+            return DisplayEndpoint.return_error(request, message="focus_node parameter empty")
+
+        focus_node = request.args["focus_node"][0]
+        if isinstance(focus_node, basestring) and not focus_node.lstrip("-").isdigit():
+            if request.args["focus_node"][0] == "self":
+                try:
+                    mc_community = self.get_multi_chain_community()
+                except OperationNotEnabledByConfigurationException as exc:
+                    return DisplayEndpoint.return_error(request, status_code=http.NOT_FOUND, message=exc.args)
+                focus_node = hexlify(mc_community.my_member.public_key)
+            else:
+                focus_node = request.args["focus_node"][0]
+        else:
+            return DisplayEndpoint.return_error(request, message="focus_node was not a string")
 
         neighbor_level = 1
         # Note that isdigit() checks if all chars are numbers, hence negative numbers are not possible to be set
@@ -89,7 +131,7 @@ class DisplayEndpoint(resource.Resource):
             neighbor_level = int(request.args["neighbor_level"][0])
 
         # TODO: Remove dummy return and change to aggregated data calculation
-        return json.dumps({"focus_node": request.args["focus_node"][0],
+        return json.dumps({"focus_node": focus_node,
                            "neighbor_level": neighbor_level,
-                           "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0}],
+                           "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0, "page_rank": 0.5}],
                            "edges": []})

--- a/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
@@ -1,19 +1,40 @@
+"""
+This module validates the functions defined in the Display Endpoint
+"""
+from twisted.internet.defer import inlineCallbacks
+
+from Tribler.community.multichain.community import MultiChainCommunity
+from Tribler.dispersy.dispersy import Dispersy
+from Tribler.dispersy.endpoint import ManualEnpoint
+from Tribler.dispersy.member import DummyMember
+from Tribler.dispersy.util import blocking_call_on_reactor_thread
 from Tribler.Test.Core.Modules.RestApi.base_api_test import AbstractApiTest
 from Tribler.Test.twisted_thread import deferred
 
 
 class TestDisplayEndpoint(AbstractApiTest):
     """
-    Test the DisplayEndpoint, the endpoint from which you can retrieve aggregated data from the multichain.
+    Evaluate the DisplayEndpoint, the endpoint from which you can retrieve aggregated data from the multichain.
     """
 
-    def setUpPreSession(self):
-        super(TestDisplayEndpoint, self).setUpPreSession()
+    @blocking_call_on_reactor_thread
+    @inlineCallbacks
+    def setUp(self, autoload_discovery=True):
+        yield super(TestDisplayEndpoint, self).setUp(autoload_discovery=autoload_discovery)
+
+        self.dispersy = Dispersy(ManualEnpoint(0), self.getStateDir())
+        self.dispersy._database.open()
+        master_member = DummyMember(self.dispersy, 1, "a" * 20)
+        self.member = self.dispersy.get_new_member(u"curve25519")
+
+        self.mc_community = MultiChainCommunity(self.dispersy, master_member, self.member)
+        self.dispersy.get_communities = lambda: [self.mc_community]
+        self.session.get_dispersy_instance = lambda: self.dispersy
 
     @deferred(timeout=10)
     def test_get_no_focus_node(self):
         """
-        Test whether the API returns an Bad Request error if there is no focus node specified.
+        Evaluate whether the API returns an Bad Request error if there is no focus node specified.
         """
         exp_message = {"error": "focus_node parameter missing"}
         return self.do_request('display?neighbor_level=1', expected_code=400, expected_json=exp_message)
@@ -21,7 +42,7 @@ class TestDisplayEndpoint(AbstractApiTest):
     @deferred(timeout=10)
     def test_get_empty_focus_node(self):
         """
-        Test whether the API returns a Bad Request error if the focus node is empty.
+        Evaluate whether the API returns a Bad Request error if the focus node is empty.
         """
         exp_message = {"error": "focus_node parameter empty"}
         return self.do_request('display?focus_node=&neighbor_level=1', expected_code=400, expected_json=exp_message)
@@ -29,19 +50,32 @@ class TestDisplayEndpoint(AbstractApiTest):
     @deferred(timeout=10)
     def test_get_neighbor_level_string(self):
         """
-        Test whether the API uses the default neighbor_level if the parameter is set to a string.
+        Evaluate whether the API uses the default neighbor_level if the parameter is set to a string.
         """
         # TODO: The dummy data is now expected, make sure to rewrite test if actual implementation is used
         exp_message = {"focus_node": "xyz", "neighbor_level": 1, "nodes": [{"public_key": "xyz", "total_up": 0,
-                                                                            "total_down": 0}], "edges": []}
+                                                                            "total_down": 0, "page_rank": 0.5}],
+                       "edges": []}
         return self.do_request('display?focus_node=xyz&neighbor_level=x', expected_code=200, expected_json=exp_message)
 
     @deferred(timeout=10)
     def test_get_neighbor_level_zero(self):
         """
-        Test whether the API uses the actual neighbor_level if the parameter is set.
+        Evaluate whether the API uses the actual neighbor_level if the parameter is set.
         """
         # TODO: The dummy data is now expected, make sure to rewrite test if actual implementation is used
         exp_message = {"focus_node": "xyz", "neighbor_level": 0, "nodes": [{"public_key": "xyz", "total_up": 0,
-                                                                            "total_down": 0}], "edges": []}
+                                                                            "total_down": 0, "page_rank": 0.5}],
+                       "edges": []}
         return self.do_request('display?focus_node=xyz&neighbor_level=0', expected_code=200, expected_json=exp_message)
+
+    @deferred(timeout=10)
+    def test_get_int_focus_node(self):
+        """
+        Evaluate whether the API returns a Bad Request error if the focus node is an integer.
+        """
+        exp_message = {"error": "focus_node was not a string"}
+        return self.do_request('display?focus_node=-1&neighbor_level=1', expected_code=400, expected_json=exp_message)
+
+        # TODO: Add method which tests:
+        # Evaluate whether the API returns the information about the own node if self is used as focus_node parameter.


### PR DESCRIPTION
This commit adds a feature so that "self" can be used as the focus_node,
which retrieves the public key from the multichain community to be used
in the further query.