### PR TITLE
READY: Pass information about nodes and edges from multichain community to display endpoint 

### DIFF
--- a/Tribler/Core/Modules/restapi/display_endpoint.py
+++ b/Tribler/Core/Modules/restapi/display_endpoint.py
@@ -24,6 +24,7 @@ class DisplayEndpoint(resource.Resource):
         resource.Resource.__init__(self)
         self.session = session
 
+
     @staticmethod
     def return_error(request, status_code=http.BAD_REQUEST, message="your request seems to be wrong"):
         """
@@ -98,7 +99,8 @@ class DisplayEndpoint(resource.Resource):
                     "edges": [{
                         "from": "xyz",
                         "to": "xyz_n1",
-                        "size": 12384
+                        "amount": 12384
+
                     }, ...]
                 }
 

--- a/Tribler/Test/Community/Multichain/test_multichain_community.py
+++ b/Tribler/Test/Community/Multichain/test_multichain_community.py
@@ -532,6 +532,52 @@ class TestMultiChainCommunity(MultiChainTestCase, DispersyTestFunc):
         assert isinstance(statistics, dict), type(statistics)
         assert len(statistics) > 0
 
+    def test_get_graph_no_public_key(self):
+        """
+        Test the get_graph method where public_key is None.
+        """
+        node, = self.create_nodes(1)
+        (nodes, edges) = node.community.get_graph(None)
+        self.assertTrue(isinstance(nodes, dict))
+        self.assertTrue(type(nodes))
+        self.assertTrue(isinstance(edges, dict))
+        self.assertTrue(type(edges))
+        self.assertGreater(len(nodes), 0)
+        self.assertGreater(len(edges), 0)
+
+    def test_get_edges_no_public_key(self):
+        """
+        Test the get_edges method where public_key is None.
+        """
+        node, = self.create_nodes(1)
+        edges = node.community.get_edges(None)
+        self.assertTrue(isinstance(edges, dict))
+        self.assertTrue(type(edges))
+        self.assertGreater(len(edges), 0)
+
+    def test_get_graph_public_key(self):
+        """
+        Test the get_nodes method where public_key is defined.
+        """
+        node, = self.create_nodes(1)
+        (nodes, edges) = node.community.get_graph()
+        self.assertTrue(isinstance(nodes, dict))
+        self.assertTrue(type(nodes))
+        self.assertTrue(isinstance(edges, dict))
+        self.assertTrue(type(edges))
+        self.assertGreater(len(nodes), 0)
+        self.assertGreater(len(edges), 0)
+
+    def test_get_edges_public_key(self):
+        """
+        Test the get_edges method where public_key is defined.
+        """
+        node, = self.create_nodes(1)
+        edges = node.community.get_edges()
+        self.assertTrue(isinstance(edges, dict))
+        self.assertTrue(type(edges))
+        self.assertGreater(len(edges), 0)
+
     @blocking_call_on_reactor_thread
     def assertBlocksInDatabase(self, node, amount):
         count = node.community.persistence.execute(u"SELECT COUNT(*) FROM multi_chain").fetchone()[0]

--- a/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
@@ -1,3 +1,4 @@
+
 """
 This module validates the functions defined in the Display Endpoint
 """

--- a/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
@@ -1,4 +1,3 @@
-
 """
 This module validates the functions defined in the Display Endpoint
 """

--- a/Tribler/community/multichain/community.py
+++ b/Tribler/community/multichain/community.py
@@ -4,6 +4,8 @@ This reputation system builds a tamper proof interaction history contained in a 
 Every node has a chain and these chains intertwine by blocks shared by chains.
 """
 import logging
+import itertools
+import networkx
 from twisted.internet.defer import inlineCallbacks
 
 from twisted.internet import reactor
@@ -23,6 +25,8 @@ from Tribler.community.multichain.block import MultiChainBlock, ValidationResult
 from Tribler.community.multichain.payload import HalfBlockPayload, CrawlRequestPayload
 from Tribler.community.multichain.database import MultiChainDB
 from Tribler.community.multichain.conversion import MultiChainConversion
+from Tribler.community.multichain.statistics.database_driver import DatabaseDriver
+from Tribler.community.multichain.statistics.page_rank import IncrementalPageRank
 
 HALF_BLOCK = u"half_block"
 CRAWL = u"crawl"
@@ -58,6 +62,9 @@ class MultiChainCommunity(Community):
 
         self.notifier = None
         self.persistence = MultiChainDB(self.dispersy.working_directory)
+        self.database = DatabaseDriver()
+        self.graph = networkx.Graph()
+        self.page_rank = IncrementalPageRank(self.graph)
 
         # We store the bytes send and received in the tunnel community in a dictionary.
         # The key is the public key of the peer being interacted with, the value a tuple of the up and down bytes
@@ -281,6 +288,93 @@ class MultiChainCommunity(Community):
             statistics["total_up"] = 0
             statistics["total_down"] = 0
         return statistics
+
+    @blocking_call_on_reactor_thread
+    def get_graph(self, public_key=None, neighbor_level=1):
+        """
+        Return a dictionary with the neighboring nodes and edges of a certain focus node within a certain radius,
+            regarding the local multichain database.
+
+        :param public_key: the public key of the focus node
+        :param neighbor_level: the radius within which the neighbors have to be returned
+        :return: a tuple of a dictionary with nodes and a dictionary with edges
+        """
+        if public_key is None:
+            public_key = self.my_member.public_key
+        list_of_nodes = self.get_list_of_nodes(public_key, neighbor_level)
+        nodes = []
+        for current_key in list_of_nodes:
+            nodes.append({"public_key": current_key, "total_up": self.database.total_up(current_key),
+                          "total_down": self.database.total_down(current_key)})
+            self.page_rank.add_node(current_key)
+        edges = self.get_edges(nodes)
+        for dic in nodes:
+            page_rank = self.get_page_rank(dic["public_key"])
+            dic["page_rank"] = page_rank
+        return nodes, edges
+
+    @blocking_call_on_reactor_thread
+    def get_list_of_nodes(self, public_key, neighbor_level):
+        """
+        Return a list of nodes surrounding a certain focus node.
+
+        :param public_key: the public key of the focus node
+        :param neighbor_level: the radius within which the neighbors have to be returned
+        :return: a list of neighbors within the given radius
+        """
+        if neighbor_level == 0:
+            return {public_key: {"up": self.database.total_up(public_key),
+                                 "down": self.database.total_down(public_key)}}
+        list_of_nodes = self.get_list_of_nodes(public_key, neighbor_level - 1)
+        for key in list_of_nodes:
+            new_neighbors = self.database.neighbor_list(key)
+            for new_key in new_neighbors:
+                if new_key not in list_of_nodes:
+                    list_of_nodes[new_key] = new_neighbors[new_key]
+        return list_of_nodes
+
+    @blocking_call_on_reactor_thread
+    def get_edges(self, nodes=None):
+        """
+        Return a dictionary with all edges between certain nodes around a certain focus node,
+            regarding the local multichain database.
+
+        :param public_key: the public key of the focus node
+        :param nodes: the dictionary of nodes between which the edges have to be returned
+        :return: a dictionary with edges
+        """
+        list_of_nodes = [node["public_key"] for node in nodes]
+        list_of_edges = []
+        for pair in itertools.combinations(list_of_nodes, 2):
+            current_neighbors = self.database.neighbor_list(pair[0])
+            list_of_edges.append(
+                [pair[0], pair[1], current_neighbors[pair[1]]["up"] or 0, current_neighbors[pair[1]]["down"] or 0])
+        number_of_edges = len(list_of_edges)
+        edges = []
+        for current in range(number_of_edges):
+            if list_of_edges[current][2] > 0:
+                edges.append({"from": list_of_edges[current][0], "to": list_of_edges[current][1],
+                              "amount": list_of_edges[current][2]})
+                self.page_rank.add_edge(list_of_edges[current][0], list_of_edges[current][1])
+            if list_of_edges[current][3] > 0:
+                edges.append({"from": list_of_edges[current][1], "to": list_of_edges[current][0],
+                              "amount": list_of_edges[current][3]})
+                self.page_rank.add_edge(list_of_edges[current][1], list_of_edges[current][0])
+        return edges
+
+    def get_page_rank(self, public_key):
+        """
+        Return the page rank of a certain node.
+
+        :param public_key: the public key of the given node
+        :return: the page rank of the given node
+        """
+        self.page_rank.initial_walk()
+        ranks = self.page_rank.get_ranks()
+        if public_key in ranks:
+            return ranks[public_key]
+        return 0
+
 
     @inlineCallbacks
     def unload_community(self):

--- a/Tribler/community/multichain/statistics/page_rank.py
+++ b/Tribler/community/multichain/statistics/page_rank.py
@@ -1,0 +1,114 @@
+"""
+This file contains everything needed to compute page ranks.
+"""
+from random import random, choice
+
+
+class IncrementalPageRank(object):
+    """
+    Class to compute page ranks according to a graph.
+    """
+    def __init__(self, graph, walks_per_node=2, stop_probability=0.1):
+        """
+        Set up the environment by setting a graph, number of walks per node and stop probability.
+        :param graph: the graph for which page ranks have to be computed
+        :param walks_per_node: the number of random walks per node
+        :param stop_probability: the probability to stop in each hop
+        """
+        self.graph = graph
+
+        self.R = walks_per_node
+        self.c = stop_probability
+
+        self.walks = list()
+        self.size = 0
+        self.counts = dict()
+        for node in self.graph.nodes():
+            self.counts[node] = 0
+
+        self.new_nodes = set()
+
+    def add_edge(self, source, destination):
+        """
+        Add an edge to the graph.
+        :param source: the source node of the new edge
+        :param destination: the destination node of the new edge
+        """
+        self.add_node(source)
+        self.add_node(destination)
+        self.graph.add_edge(source, destination)
+
+
+    def add_node(self, node):
+        """
+        Add a node to the graph.
+        :param node: the name for the new node
+        """
+        self.new_nodes.add(node)
+        if node not in self.graph.nodes():
+            self.graph.add_node(node)
+
+    def initial_walk(self):
+        """
+        Perform the initial random walk.
+        """
+        self.size = 0
+        for node in self.graph.nodes():
+            walks = list()
+            for _ in range(self.R):
+                new_walk = self._walk(node)
+                walks.append(self._walk(node))
+                self.size += len(new_walk)
+            self.walks.append(walks)
+
+    def update_walk(self):
+        """
+        Update the stored random walks incrementally.
+        """
+        self.size = 0
+        for node_walks in range(len(self.walks)):
+            for walk in range(len(self.walks[node_walks])):
+                reset_walk = False
+                for hop in self.walks[node_walks][walk]:
+                    if hop in self.new_nodes:
+                        reset_walk = True
+                        break
+                if reset_walk:
+                    new_walk = self._walk(self.walks[node_walks][walk][0])
+                    self.walks[node_walks][walk] = new_walk
+                self.size += len(self.walks[node_walks][walk])
+
+    def _walk(self, start):
+        """
+        Perform a random walk, starting from a certain node.
+        :param start: the start node
+        :return: a list that represents the walk
+        """
+        walk = list()
+        next_node = start
+        while random() > self.c:
+            walk.append(next_node)
+            neighbors = self.graph.neighbors(next_node)
+            if len(neighbors) == 0:
+                continue
+            next_node = choice(neighbors)
+        return walk
+
+    def count(self):
+        """
+        For each node, count the number of occurrences in the random walks.
+        :return: a dictionary in which the number of occurrences can be looked up by node name
+        """
+        flat = list()
+        for node_walk in self.walks:
+            for walk in node_walk:
+                for hit in walk:
+                    flat.append(hit)
+        self.counts = {hop: flat.count(hop) for hop in self.graph.nodes()}
+
+    def get_ranks(self):
+        """
+        For each node, get its page rank.
+        :return: a dictionary in which a node's page rank can be looked up by its name
+        """
+        return {hop: self.counts[hop] / self.size for hop in self.graph.nodes()}

--- a/Tribler/community/multichain/statistics/page_rank.py
+++ b/Tribler/community/multichain/statistics/page_rank.py
@@ -11,6 +11,7 @@ class IncrementalPageRank(object):
     def __init__(self, graph, walks_per_node=2, stop_probability=0.1):
         """
         Set up the environment by setting a graph, number of walks per node and stop probability.
+
         :param graph: the graph for which page ranks have to be computed
         :param walks_per_node: the number of random walks per node
         :param stop_probability: the probability to stop in each hop
@@ -31,6 +32,7 @@ class IncrementalPageRank(object):
     def add_edge(self, source, destination):
         """
         Add an edge to the graph.
+
         :param source: the source node of the new edge
         :param destination: the destination node of the new edge
         """
@@ -42,6 +44,7 @@ class IncrementalPageRank(object):
     def add_node(self, node):
         """
         Add a node to the graph.
+
         :param node: the name for the new node
         """
         self.new_nodes.add(node)
@@ -81,6 +84,7 @@ class IncrementalPageRank(object):
     def _walk(self, start):
         """
         Perform a random walk, starting from a certain node.
+
         :param start: the start node
         :return: a list that represents the walk
         """
@@ -97,6 +101,7 @@ class IncrementalPageRank(object):
     def count(self):
         """
         For each node, count the number of occurrences in the random walks.
+
         :return: a dictionary in which the number of occurrences can be looked up by node name
         """
         flat = list()
@@ -109,6 +114,7 @@ class IncrementalPageRank(object):
     def get_ranks(self):
         """
         For each node, get its page rank.
+
         :return: a dictionary in which a node's page rank can be looked up by its name
         """
         return {hop: self.counts[hop] / self.size for hop in self.graph.nodes()}


### PR DESCRIPTION
This branch carries a squash of all the commits in get_statistics, see https://github.com/vandenheuvel/tribler/pull/70/. Discussion and reviews have started there.