### PR TITLE
Fix the GUI tests

### DIFF
--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -516,8 +516,8 @@ class TriblerGUITest(AbstractTriblerGUITest):
         QTest.mouseClick(window.edit_channel_manage_playlist_save_button, Qt.LeftButton)
 
     def test_trust_page(self):
-        QTest.mouseClick(window.trust_button, Qt.LeftButton)
-        self.wait_for_variable("trust_page.blocks")
+        QTest.mouseClick(window.left_menu_button_trust_display, Qt.LeftButton)
+        # Since the trust page is rendered in JavaScript, it is tested there.
         self.screenshot(window, name="trust_page_values")
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR, the button clicked in the GUI tests is changed, so that
it clicks the newly created button rather than the old nonexisting
button.