### PR TITLE
Failing integration test fix

### DIFF
--- a/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
@@ -72,10 +72,12 @@ class TestDisplayEndpoint(AbstractApiTest):
     @deferred(timeout=10)
     def test_get_int_focus_node(self):
         """
-        Evaluate whether the API returns a Bad Request error if the focus node is an integer.
+        Evaluate whether the API returns a correct response if the focus node is an integer.
         """
-        exp_message = {"error": "focus_node was not a string"}
-        return self.do_request('display?focus_node=-1&neighbor_level=1', expected_code=400, expected_json=exp_message)
+        exp_message = {"focus_node": "-1", "neighbor_level": 1, "nodes": [{"public_key": "xyz", "total_up": 0,
+                                                                            "total_down": 0, "page_rank": 0.5}],
+                       "edges": []}
+        return self.do_request('display?focus_node=-1&neighbor_level=1', expected_code=200, expected_json=exp_message)
 
         # TODO: Add method which tests:
         # Evaluate whether the API returns the information about the own node if self is used as focus_node parameter.

--- a/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_display_endpoint.py
@@ -75,7 +75,7 @@ class TestDisplayEndpoint(AbstractApiTest):
         Evaluate whether the API returns a correct response if the focus node is an integer.
         """
         exp_message = {"focus_node": "-1", "neighbor_level": 1, "nodes": [{"public_key": "xyz", "total_up": 0,
-                                                                            "total_down": 0, "page_rank": 0.5}],
+                                                                           "total_down": 0, "page_rank": 0.5}],
                        "edges": []}
         return self.do_request('display?focus_node=-1&neighbor_level=1', expected_code=200, expected_json=exp_message)
 


### PR DESCRIPTION
This PR fixes the failing test for the display endpoint.

The original version assumed that a request with a string representing an integer was a false key, but hashes might return integer-only results. PR #98 fixed the check in the display_endpoint, but the test case was not altered.