### PR TITLE
Trust statistics database

### DIFF
--- a/Tribler/Test/Community/Multichain/statistics/test_statistics_database_new.py
+++ b/Tribler/Test/Community/Multichain/statistics/test_statistics_database_new.py
@@ -1,0 +1,83 @@
+"""
+This file contains the database connection used for the statistics display.
+"""
+import os
+from twisted.internet.defer import inlineCallbacks
+
+from Tribler.community.multichain.database import DATABASE_DIRECTORY
+from Tribler.community.multichain.statistics.statistics_database import StatisticsDB
+from Tribler.Test.Community.Multichain.test_multichain_utilities import TestBlock
+from Tribler.Test.test_as_server import AbstractServer
+
+
+class TestStatisticsDatabase(AbstractServer):
+    """
+    Tests for the trust statistics database connection.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestStatisticsDatabase, self).__init__(*args, **kwargs)
+
+    @inlineCallbacks
+    def setUp(self, annotate=True):
+        yield super(TestStatisticsDatabase, self).setUp(annotate=annotate)
+        path = os.path.join(self.getStateDir(), DATABASE_DIRECTORY)
+        if not os.path.exists(path):
+            os.makedirs(path)
+        self.db = StatisticsDB(self.getStateDir())
+        self.block1 = TestBlock()
+        self.block2 = TestBlock()
+        self.block3 = TestBlock()
+
+    def test_total_up(self):
+        """
+        The database should return the correct amount of uploaded data.
+        """
+        self.block2.total_up = 0
+
+        self.db.add_block(self.block1)
+        self.db.add_block(self.block2)
+
+        self.assertEqual(self.block1.total_up, self.db.total_up(self.block1.public_key))
+        self.assertEqual(0, self.db.total_up(self.block2.public_key))
+        self.assertEqual(0, self.db.total_up(self.block3.public_key))
+
+    def test_total_down(self):
+        """
+        The database should return the correct amount of downloaded data.
+        """
+        self.block2.total_down = 0
+
+        self.db.add_block(self.block1)
+        self.db.add_block(self.block2)
+
+        self.assertEqual(self.block2.total_down, self.db.total_down(self.block2.public_key))
+        self.assertEqual(0, self.db.total_down(self.block2.public_key))
+        self.assertEqual(0, self.db.total_down(self.block3.public_key))
+
+    def test_neighbors(self):
+        """
+        The database should return the correct list of neighbors and the traffic to and from them.
+        """
+        focus_block1 = TestBlock()
+        focus_block2 = TestBlock()
+
+        # All blocks have the same public key
+        self.block2.public_key = self.block1.public_key
+        self.block3.public_key = self.block1.public_key
+
+        self.block1.link_public_key = focus_block1.public_key
+        self.block2.link_public_key = focus_block1.public_key
+        self.block3.link_public_key = focus_block2.public_key
+
+        # Add all blocks + one redundant block
+        self.db.add_block(self.block1)
+        self.db.add_block(self.block2)
+        self.db.add_block(self.block3)
+        self.db.add_block(focus_block1)
+
+        expected_result = {focus_block1.public_key:
+                               {"up": self.block1.up + self.block2.up, "down": self.block1.down + self.block2.down},
+                           focus_block2.public_key: {"up": self.block3.up, "down": self.block3.down}}
+
+        self.assertDictEqual(expected_result, self.db.neighbor_list(self.block1.public_key))

--- a/Tribler/community/multichain/statistics/statistics_database.py
+++ b/Tribler/community/multichain/statistics/statistics_database.py
@@ -1,0 +1,57 @@
+"""
+This file contains the functions to get the trust statistics from the database implemented in Tribler.
+"""
+from Tribler.community.multichain.database import MultiChainDB
+
+
+class StatisticsDB(MultiChainDB):
+    """
+    Statistics connection for the trust chain database.
+    """
+
+    def __init__(self, working_directory):
+        """
+        Sets up a database connection to the existing multi chain database.
+        :param working_directory: directory of the database
+        """
+        super(StatisticsDB, self).__init__(working_directory)
+
+    def total_up(self, public_key):
+        """
+        Gets the total uploaded value from the focus.
+        :param public_key: public key of the focus node
+        :return: number representing the amount of uploaded data
+        """
+        block = self.get_latest(public_key)
+        return block.total_up if block else 0
+
+    def total_down(self, public_key):
+        """
+        Gets the total downloaded value from the focus.
+        :param public_key: public key of the focus node
+        :return: number representing the amount of uploaded data
+        """
+        block = self.get_latest(public_key)
+        return block.total_down if block else 0
+
+    def neighbor_list(self, public_key):
+        """
+        Return a dictionary containing information about all neighbors of the focus node.
+        For each neighbor, the dictionary contains a key equal to the primary key of the neighbor.
+        The value stored under that key is a dictionary containing how much data has been uploaded
+        and downloaded to and from that neighbor.
+        :param public_key: primary key of the focus node
+        :return: dictionary with for each neighbor of the focus a key, value entry: primary key neighbor, dictionary
+        containing the amount of data uploaded and downloaded from that neighbor
+        """
+        query = u"SELECT link_public_key, sum(up), sum(down) FROM multi_chain " \
+                u"WHERE public_key = ? GROUP BY link_public_key"
+        params = (buffer(public_key),)
+        db_result = self.execute(query, params).fetchall()
+
+        neighbors = {}
+        for row in db_result:
+            neighbor_pk = row[0] if isinstance(row[0], str) else str(row[0])
+            neighbors[neighbor_pk] = {"up": row[1] or 0, "down": row[2] or 0}
+
+        return neighbors


### PR DESCRIPTION
This PR adds a connection to the existing trust chain database in Tribler to get the trust statistics from.

Implements issue #90.

Replaces PR #94 