### PR TITLE
FROZEN: Add import to test_gui.py

### DIFF
--- a/Tribler/Test/GUI/test_gui.py
+++ b/Tribler/Test/GUI/test_gui.py
@@ -7,7 +7,8 @@ from unittest import skipUnless
 from PyQt5.QtCore import QPoint, Qt, QTimer
 from PyQt5.QtGui import QPixmap, QRegion
 from PyQt5.QtTest import QTest
-# TODO: Fix GUI tests by importing PyQt5.QtWebEngineWidgets, this can be done after CI is updated.
+# QtWebEngineWidgets must be imported before a QCoreApplication instance is created, otherwise an import error occurs
+from PyQt5.QtWebEngineWidgets import QWebEngineView
 from PyQt5.QtWidgets import QApplication, QListWidget, QTreeWidget
 
 from Tribler.Core.Utilities.network_utils import get_random_port


### PR DESCRIPTION
Since the dependencies have now been added correctly, we can now use the
import in order for the tests to work. This commit enables this by
importing QtWebEngineWidgets