### PR TITLE
READY: Display quantitative information when hovering over nodes and links

### DIFF
--- a/TriblerGUI/widgets/trustpage/js/data_processor.js
+++ b/TriblerGUI/widgets/trustpage/js/data_processor.js
@@ -159,11 +159,9 @@ function addMinMaxTransmission(response, interim) {
         pk = response.focus_node;
 
     interim.links.forEach(function (link) {
-        if (link.target_pk === pk || link.source_pk === pk) {
             var total = link.amount_up + link.amount_down;
             if (min === -1 || total < min) min = total;
             if (max === -1 || total > max) max = total;
-        }
     });
 
     return {

--- a/TriblerGUI/widgets/trustpage/js/style_config.js
+++ b/TriblerGUI/widgets/trustpage/js/style_config.js
@@ -6,16 +6,16 @@ var config = {
     link : {
         colorLinkSource : "#ffff00",
         colorLinkTarget : "#ff0000",
-        strokeWidthMin : 2,
+        strokeWidthMin : 6,
         strokeWidthMax : 10
     },
     node : {
         publicKeyLabel : {
-            color : "#ffff00",
-            fontSize : "12",
+            color : "#000000",
+            fontSize : "14",
             fontFamily : "sans-serif",
-            x : 24,
-            y : 24
+            fontWeight : "bold",
+            characters : 3
         },
         circle : {
             radius : 20,
@@ -26,6 +26,12 @@ var config = {
         color : {
             domain : [0, 0.5, 1],
             range : ["red", "yellow", "green"]
+        },
+        hoverLabel : {
+            publicKeyCharacters : 5,
+            pageRankDecimals : 4,
+            opacityOnNode : 1,
+            opacityOnEdge : 0.8
         }
     },
     radius_step: 120

--- a/TriblerGUI/widgets/trustpage/style.css
+++ b/TriblerGUI/widgets/trustpage/style.css
@@ -8,11 +8,30 @@ html, body {
     overflow: hidden;
 }
 
+.line {
+	box-shadow: 10px 10px 5px #888888;
+}
+
+.quantity {
+	padding: 0 10px 0 0;
+}
+
 svg {
     display: block;
     margin: 0 auto;
     height: 100%;
     width: 100%;
+}
+
+.hoverInfoLabel {
+	position: absolute;
+	padding: 7px;
+	font: 12px sans-serif;
+	background: lightsteelblue;
+	border: 0px;
+	border-radius: 8px;
+	pointer-events: none;
+	display: table;
 }
 
 .tooltip {


### PR DESCRIPTION
Solves #171 

Note: this branch is setup with the example dataset for the sake of easy development. This will be reverted before merge.

Current status (using a table now):
![info_new](https://cloud.githubusercontent.com/assets/15815946/26523554/608f321a-431a-11e7-9ea0-ff4d71db6ee5.png)
![edge_info](https://cloud.githubusercontent.com/assets/15815946/26530760/65ffafec-43db-11e7-8841-9925fb7db774.png)
