### PR TITLE
READY: Remove relative paths

### DIFF
--- a/TriblerGUI/test/widgets/trustpage/js/test_data_processor.js
+++ b/TriblerGUI/test/widgets/trustpage/js/test_data_processor.js
@@ -2,7 +2,7 @@
  * This file tests the data_processor.js file with unit tests
  */
 assert = require('assert');
-processor = require('../../../../widgets/trustpage/js/data_processor.js');
+processor = require('TriblerGUI/widgets/trustpage/js/data_processor.js');
 
 describe('data_processor.js', function () {
 

--- a/TriblerGUI/test/widgets/trustpage/js/test_drawing.js
+++ b/TriblerGUI/test/widgets/trustpage/js/test_drawing.js
@@ -3,8 +3,8 @@
  */
 
 assert = require("assert");
-config = require("../../../../widgets/trustpage/js/style_config.js");
-drawing = require("../../../../widgets/trustpage/js/drawing.js");
+config = require("TriblerGUI/widgets/trustpage/js/style_config.js");
+drawing = require("TriblerGUI/widgets/trustpage/js/drawing.js");
 
 describe("drawing.js", function () {
     describe("getStrokeWidth", function () {


### PR DESCRIPTION
Fixes #153. Javascript tests should now be run using
**either**
`NODE_PATH=<path_to_tribler> node usr/local/bin/mocha --recursive TriblerGUI/test/widgets/trustpage/js`
**or**
`export NODE_PATH=<path_to_tribler>`
`node usr/local/bin/mocha --recursive TriblerGUI/test/widgets/trustpage/js`,

where `<path_to_tribler>` is the path to your local Tribler clone, in my case `~/Documents/tribler/`