### PR TITLE
READY: Remove/hide scroll bar on trust display

### DIFF
--- a/TriblerGUI/widgets/trustpage/index.html
+++ b/TriblerGUI/widgets/trustpage/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <!-- THE GRAPH -->
-<svg id="graph" width="600" height="600"></svg>
+<svg id="graph" width="600" height="600" viewBox="0 0 600 600"></svg>
 <div class="tooltip">
     <div id="tooltip-content">
         <p id="header">Nodes</p>

--- a/TriblerGUI/widgets/trustpage/style.css
+++ b/TriblerGUI/widgets/trustpage/style.css
@@ -5,11 +5,13 @@ html, body {
     height: 100%;
     /*display: table;*/
     background-color: #202020;
+    overflow: hidden;
 }
 
 svg {
     display: block;
     margin: 0 auto;
+    width: 100%;
 }
 
 .tooltip {


### PR DESCRIPTION
Fixes #100. If the window size is too small for the graph to fit, the graph is shrunk, instead of showing scroll bars.
See the difference below:
![small](https://cloud.githubusercontent.com/assets/15821371/26579742/5d92b6f0-4535-11e7-93e7-696d3966c890.png)
![normal](https://cloud.githubusercontent.com/assets/15821371/26579741/5d91914e-4535-11e7-8b73-adaa22033869.png)
