### PR TITLE
READY: Hotfix previous focus

### DIFF
--- a/TriblerGUI/widgets/trustpage/js/main.js
+++ b/TriblerGUI/widgets/trustpage/js/main.js
@@ -133,11 +133,13 @@ function update(graph) {
         var previous_focus = state.tree.nodes.find(function(node){
             return node.graphNode.public_key === state.previous_focus_pk;
         });
-        var correction = target_angle - previous_focus.alpha;
+        if (previous_focus) {
+            var correction = target_angle - previous_focus.alpha;
 
-        state.tree.nodes.forEach(function (node) {
-            node.alpha += correction;
-        });
+            state.tree.nodes.forEach(function (node) {
+                node.alpha += correction;
+            });
+        }
     }
 
     // Draw all nodes


### PR DESCRIPTION
Small error made in radial layout. When a new data-set is loaded and the previous focus node is no longer in that data-set the code fails. Actually, this should not be possible but is caused by another bug in the backend. Still, it is better to have this check.