### PR TITLE
Reverse order in tooltip link

### DIFF
--- a/TriblerGUI/widgets/trustpage/js/radial_view/radial_tooltip.js
+++ b/TriblerGUI/widgets/trustpage/js/radial_view/radial_tooltip.js
@@ -77,8 +77,8 @@ function RadialToolTip() {
     self.displayLinkData = function (link) {
         // The quantity descriptions and the corresponding values
         var quantities = [
-            ["Uploaded by ..." + link.target_pk.substr(-config.node.hoverLabel.publicKeyCharacters), formatBytes(link.amount_up)],
-            ["Uploaded by ..." + link.source_pk.substr(-config.node.hoverLabel.publicKeyCharacters), formatBytes(link.amount_down)]
+            ["Uploaded by ..." + link.target_pk.substr(-config.node.hoverLabel.publicKeyCharacters), formatBytes(link.amount_down)],
+            ["Uploaded by ..." + link.source_pk.substr(-config.node.hoverLabel.publicKeyCharacters), formatBytes(link.amount_up)]
         ];
 
         // Update the label with the information corresponding to the link


### PR DESCRIPTION
This fixes the bug where the amounts uploaded were displayed in the
reverse order e.g. if 1 uploaded to 2, the tooltip would say that 2 had
uploaded to 1. This is now fixed.

Fixes #281 