### PR TITLE
Optimize database utilization visualization

### DIFF
--- a/Tribler/Test/Community/Multichain/test_multichain_community.py
+++ b/Tribler/Test/Community/Multichain/test_multichain_community.py
@@ -528,6 +528,61 @@ class TestMultiChainCommunity(MultiChainTestCase, DispersyTestFunc):
         assert isinstance(statistics, dict), type(statistics)
         assert len(statistics) > 0
 
+    def test_get_node_empty(self):
+        """
+        Check whether get_node returns the correct node if no past data is given.
+        """
+        node, = self.create_nodes(1)
+        self.assertEqual({"public_key": "test", "total_up": 3, "total_down": 5},
+                         node.community.get_node("test", [], 3, 5))
+
+    def test_get_node_maximum(self):
+        """
+        Check whether get_node returns the maximum of total_up and total_down.
+        """
+        node, = self.create_nodes(1)
+        nodes = {"test": {"public_key": "test", "total_up": 1, "total_down": 10}}
+        self.assertEqual({"public_key": "test", "total_up": 3, "total_down": 10},
+                         node.community.get_node("test", nodes, 3, 5))
+
+    def test_get_node_request_latest(self):
+        """
+        Check whether get_node requires a block from get_latest method if no total_up and total_down is given.
+        """
+        node, = self.create_nodes(1)
+        node.community.persistence.get_latest = lambda _: MultiChainBlock((0, 0, 5, 6, 0, 0, 0, 0, 0, 0, 0))
+        node.community.persistence.total_traffic = lambda _: (0, 0)
+        self.assertEqual({"public_key": '74657374', "total_up": 5, "total_down": 6},
+                         node.community.get_node('74657374', []))
+
+    def test_get_node_request_total_traffic(self):
+        """
+        Check whether get_node requires a total_traffic method if no total_up and total_down is given.
+        """
+        node, = self.create_nodes(1)
+        node.community.persistence.get_latest = lambda _: None
+        node.community.persistence.total_traffic = lambda _: [5, 6]
+        self.assertEqual({"public_key": '74657374', "total_up": 5, "total_down": 6},
+                         node.community.get_node('74657374', []))
+
+    def test_update_edges_empty(self):
+        """
+        Check whether update_edges updates edges when the dictionary is empty.
+        """
+        node, = self.create_nodes(1)
+        edges = {}
+        node.community.update_edges("test1", "test2", edges, 5)
+        self.assertEqual({"test1": {"test2": 5}}, edges)
+
+    def test_update_edges_update(self):
+        """
+        Check whether update_edges updates edges when there is already an entrance.
+        """
+        node, = self.create_nodes(1)
+        edges = {"test1": {"test2": 6}}
+        node.community.update_edges("test1", "test2", edges, 5)
+        self.assertEqual({"test1": {"test2": 11}}, edges)
+
     def test_get_graph_without_ranks(self):
         """
         Test the get_graph method without cached ranks.


### PR DESCRIPTION
In this PR, the way of querying the database receives an overhaul.
The queries for each individual edge are removed and are instead placed
in one big query, which speeds up the process drastically. There are now
new methods in place which can correctly handle the new format and
convert it to the same format as before this commit.

Fixes #258 