### PR TITLE
READY: Fix disappearing edges

### DIFF
--- a/TriblerGUI/widgets/trustpage/js/radial_view/radial_link.js
+++ b/TriblerGUI/widgets/trustpage/js/radial_view/radial_link.js
@@ -38,7 +38,7 @@ function RadialLinks(svg, options) {
                 return link.id;
             });
 
-        self.destroy(self.selectAll());
+        self.destroy(update.exit());
         self.update(update);
         self.create(update.enter());
     };


### PR DESCRIPTION
In this PR, the destroying of edges is limited only to the ones that
have to be deleted, rather than to all existing edges before clicking a
new node.

Fixes #277 