### PR TITLE
Score backend

### DIFF
--- a/Tribler/Core/Modules/restapi/trustchain_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustchain_endpoint.py
@@ -260,6 +260,7 @@ class TrustChainNetworkEndpoint(resource.Resource):
                         "public_key": "xyz",
                         "total_up": 12736457,
                         "total_down": 1827364,
+                        "score": 0.3
                     }, ...],
                     "edges": [{
                         "from": "xyz",

--- a/Tribler/Test/Community/Triblerchain/test_score.py
+++ b/Tribler/Test/Community/Triblerchain/test_score.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from Tribler.community.triblerchain.score import calculate_score, BOUNDARY_VALUE
+
+
+class TestScore(TestCase):
+    @staticmethod
+    def create_node(public_key="TEST", total_up=0, total_down=0):
+        return {"public_key": public_key, "total_up": total_up, "total_down": total_down}
+
+    def test_calculate_score_below(self):
+        self.assertEqual(0, calculate_score(self.create_node(total_down=BOUNDARY_VALUE + 1)))
+
+    def test_calculate_score_above(self):
+        self.assertEqual(1, calculate_score(self.create_node(total_up=BOUNDARY_VALUE + 1)))
+
+    def test_calculate_score_between(self):
+        self.assertEqual(0.75, calculate_score(self.create_node(total_up=BOUNDARY_VALUE / 2)))

--- a/Tribler/Test/Core/Modules/RestApi/test_trustchain_network_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_trustchain_network_endpoint.py
@@ -82,11 +82,11 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         Evaluate whether the API passes the correct data if there are no edges returned.
         """
         self.tribler_chain_community.get_graph = lambda public_key, neighbor_level: (
-            [{"public_key": "xyz", "total_up": 0, "total_down": 0}], [])
+            [{"public_key": "xyz", "total_up": 0, "total_down": 0, "score": 0.5}], [])
         exp_message = {"user_node": hexlify(self.tribler_chain_community.my_member.public_key),
                        "focus_node": "30",
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0}],
+                       "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0, "score": 0.5}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("trustchain", 30, 1)
         self.assertEqual(dumps(exp_message), network_endpoint.render_GET(request))
@@ -96,12 +96,12 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         Evaluate whether the API passes the correct data if there are edges returned.
         """
         self.tribler_chain_community.get_graph = lambda public_key, neighbor_level: (
-            [{"public_key": "xyz", "total_up": 0, "total_down": 0}], [
+            [{"public_key": "xyz", "total_up": 0, "total_down": 0, "score": 0.5}], [
                 {"from": "xyz", "to": "abc", "amount": 30}])
         exp_message = {"user_node": hexlify(self.tribler_chain_community.my_member.public_key),
                        "focus_node": "30",
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0}],
+                       "nodes": [{"public_key": "xyz", "total_up": 0, "total_down": 0, "score": 0.5}],
                        "edges": [{"from": "xyz", "to": "abc", "amount": 30}]}
         network_endpoint, request = self.set_up_endpoint_request("trustchain", 30, 1)
         self.assertEqual(dumps(exp_message), network_endpoint.render_GET(request))
@@ -114,7 +114,7 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         exp_message = {"user_node": user_public_key,
                        "focus_node": user_public_key,
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0}],
+                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("trustchain", "self", 1)
         self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
@@ -127,7 +127,7 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         exp_message = {"user_node": user_public_key,
                        "focus_node": hexlify(self.member.public_key),
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0}],
+                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("trustchain", "self", -1)
         self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
@@ -140,7 +140,7 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         exp_message = {"user_node": user_public_key,
                        "focus_node": user_public_key,
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0}],
+                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("", "self", 1)
         self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
@@ -150,7 +150,7 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         Evaluate whether the API sends a response when the dataset is not defined.
         """
         user_public_key = hexlify(self.member.public_key)
-        exp_message = {"nodes": [{"public_key": user_public_key, "total_down": 0, "total_up": 0}],
+        exp_message = {"nodes": [{"public_key": user_public_key, "total_down": 0, "total_up": 0, "score": 0.5}],
                        "neighbor_level": 1,
                        "user_node": user_public_key,
                        "focus_node": user_public_key,

--- a/Tribler/community/triblerchain/community.py
+++ b/Tribler/community/triblerchain/community.py
@@ -7,6 +7,7 @@ from twisted.internet.task import LoopingCall
 from Tribler.Core.simpledefs import NTFY_TUNNEL, NTFY_REMOVE
 from Tribler.community.triblerchain.block import TriblerChainBlock
 from Tribler.community.triblerchain.database import TriblerChainDB
+from Tribler.community.triblerchain.score import calculate_score
 from Tribler.community.trustchain.community import TrustChainCommunity
 from Tribler.dispersy.util import blocking_call_on_reactor_thread
 
@@ -237,6 +238,10 @@ class TriblerChainCommunity(TrustChainCommunity):
 
         return_nodes = nodes.values()
         return_edges = []
+
+        for node in return_nodes:
+            node["score"] = calculate_score(node)
+
         for from_pk, edge_list in edges.iteritems():
             new_edges = [{"from": from_pk, "to": to_pk, "amount": amount} for to_pk, amount in edge_list.iteritems()]
             return_edges += new_edges

--- a/Tribler/community/triblerchain/score.py
+++ b/Tribler/community/triblerchain/score.py
@@ -1,0 +1,25 @@
+"""
+This module is used to calculate the score for a node.
+"""
+BOUNDARY_VALUE = pow(10, 9)
+
+
+def calculate_score(node):
+    """
+    Calculate the score given a node dictionary.
+
+    The given node is in the following format:
+        { "public_key": public_key, "total_up": total_up, "total_down": total_down }
+
+    The score is calculated on a scale from 0 till 1, where 0 is the worst and 1 is the best.
+
+    :param node: the node for which the score has to be calculated
+    :return: a number between 0 and 1 which represents the score of the node.
+    """
+    balance = node["total_up"] - node["total_down"]
+    if balance < -BOUNDARY_VALUE:
+        return 0
+    elif balance > BOUNDARY_VALUE:
+        return 1
+    else:
+        return (float(balance) + BOUNDARY_VALUE) / (BOUNDARY_VALUE + BOUNDARY_VALUE)

--- a/TriblerGUI/test/widgets/trustpage/js/test_data_processor.js
+++ b/TriblerGUI/test/widgets/trustpage/js/test_data_processor.js
@@ -52,7 +52,8 @@ describe('data_processor.js', function () {
             assert.deepEqual(result.nodes, [{
                 public_key: 'aaa',
                 total_up: 5,
-                total_down: 10
+                total_down: 10,
+                score: 0.5
             }]);
         });
     });
@@ -298,9 +299,9 @@ describe('data_processor.js', function () {
 
     function getTestData() {
         return {
-            node1: {public_key: 'aaa', total_up: 5, total_down: 10},
-            node2: {public_key: 'bbb', total_up: 110, total_down: 50},
-            node3: {public_key: 'ccc', total_up: 40, total_down: 50},
+            node1: {public_key: 'aaa', total_up: 5, total_down: 10, score: 0.5},
+            node2: {public_key: 'bbb', total_up: 110, total_down: 50, score: 0.3},
+            node3: {public_key: 'ccc', total_up: 40, total_down: 50, score: 0.2},
             edge1to2: {from: "aaa", to: "bbb", amount: 4},
             edge2to1: {from: "bbb", to: "aaa", amount: 16},
             edge1to3: {from: "aaa", to: "bbb", amount: 5}

--- a/TriblerGUI/widgets/trustpage/js/data_processor.js
+++ b/TriblerGUI/widgets/trustpage/js/data_processor.js
@@ -56,14 +56,15 @@ function convertResponse(response, converters) {
  * Map the GraphResponseNode to GraphNode objects
  *
  * @param {GraphResponseData} response - The response
- * @returns {{edges: GraphEdge[]}}
+ * @returns {{nodes: GraphNode[]}}
  */
 function mapNodes(response) {
     var nodes = response.nodes.map(function (node) {
         return {
             public_key: node.public_key,
             total_up: node.total_up,
-            total_down: node.total_down
+            total_down: node.total_down,
+            score: node.score
         }
     });
 
@@ -343,6 +344,7 @@ function groupBy(list, key) {
  * @property {number} local_key      - the local key of this node (corresponds with GraphData.local_keys)
  * @property {number} total_up       - the total upload by this node
  * @property {number} total_down     - the total download by this node
+ * @property {number} score          - the score between 0 and 1 for the rating in the network of the node
  * @property {boolean} is_user       - true if this node represents the user
  * @property {GraphNode[]} neighbors - the list of neighbors of this node
  */

--- a/TriblerGUI/widgets/trustpage/js/radial_view/radial_node.js
+++ b/TriblerGUI/widgets/trustpage/js/radial_view/radial_node.js
@@ -246,13 +246,7 @@ function RadialNodes(svg, options) {
         var nodeColor = d3.scaleLinear()
             .domain(self.config.color.domain)
             .range(self.config.color.range);
-
-        var difference = node.total_up - node.total_down;
-        difference = Math.max(difference, self.config.upDownDifferenceDomain.min);
-        difference = Math.min(difference, self.config.upDownDifferenceDomain.max);
-
-        var rangeSize = self.config.upDownDifferenceDomain.max - self.config.upDownDifferenceDomain.min;
-        return nodeColor((difference - self.config.upDownDifferenceDomain.min) / rangeSize);
+        return nodeColor(node.score);
     };
 
 }

--- a/TriblerGUI/widgets/trustpage/js/request_data.js
+++ b/TriblerGUI/widgets/trustpage/js/request_data.js
@@ -77,7 +77,7 @@ function get_node_info(public_key, neighbor_level, callback) {
  * @property {String} focus_node         - The public key of the focus node
  * @property {number} neighbor_level     - The neighbor level
  * @property {GraphResponseNode[]} nodes - The nodes
- * @property {GraphResponseEdge[]} edges - The edges*
+ * @property {GraphResponseEdge[]} edges - The edges
  */
 
 /**
@@ -92,4 +92,5 @@ function get_node_info(public_key, neighbor_level, callback) {
  * @property {String} public_key - The public key of the node
  * @property {number} total_up   - The total amount of MB uploaded by the node
  * @property {number} total_down - The total amount of MB downloaded by the node
+ * @property {number} score      - the score between 0 and 1 for the rating in the network of the node
  */

--- a/TriblerGUI/widgets/trustpage/js/style_config.js
+++ b/TriblerGUI/widgets/trustpage/js/style_config.js
@@ -56,12 +56,7 @@ var config = {
         },
         highlightDimmedOpacity: 0.5,
         highlightInDuration: 200,
-        highlightOutDuration: 1000,
-        // TODO: Move these configuration items to the core
-        upDownDifferenceDomain: {
-            min: -100,
-            max: 500
-        }
+        highlightOutDuration: 1000
     },
     tooltip: {
         background: "#FFFFFF"


### PR DESCRIPTION
In this PR, a score attribute is added to the node object in the
TriblerChain community. This score is a number between 0 and 1,
indicating the score of the node in the network. Although this is now
calculated with an easy method, this can be adjusted to any other
calculation in the future.

Fixes #319 