### PR TITLE
Add total neighbors to display

### DIFF
--- a/Tribler/Core/Modules/restapi/trustchain_endpoint.py
+++ b/Tribler/Core/Modules/restapi/trustchain_endpoint.py
@@ -260,7 +260,8 @@ class TrustChainNetworkEndpoint(resource.Resource):
                         "public_key": "xyz",
                         "total_up": 12736457,
                         "total_down": 1827364,
-                        "score": 0.3
+                        "score": 0.0011,
+                        "total_neighbors": 1
                     }, ...],
                     "edges": [{
                         "from": "xyz",

--- a/Tribler/Test/Community/Triblerchain/test_community.py
+++ b/Tribler/Test/Community/Triblerchain/test_community.py
@@ -359,25 +359,25 @@ class TestTriblerChainCommunity(BaseTestTrustChainCommunity):
         Check whether get_node returns the correct node if no past data is given.
         """
         node, = self.create_nodes(1)
-        self.assertEqual({"public_key": "test", "total_up": 3, "total_down": 5},
-                         node.community.get_node("test", [], 3, 5))
+        self.assertEqual({"public_key": "test", "total_up": 3, "total_down": 5, "total_neighbors": 2},
+                         node.community.get_node("test", [], 3, 5, 2))
 
     def test_get_node_maximum(self):
         """
         Check whether get_node returns the maximum of total_up and total_down.
         """
         node, = self.create_nodes(1)
-        nodes = {"test": {"public_key": "test", "total_up": 1, "total_down": 10}}
-        self.assertEqual({"public_key": "test", "total_up": 3, "total_down": 10},
-                         node.community.get_node("test", nodes, 3, 5))
+        nodes = {"test": {"public_key": "test", "total_up": 1, "total_down": 10, "total_neighbors": 2}}
+        self.assertEqual({"public_key": "test", "total_up": 3, "total_down": 10, "total_neighbors": 2},
+                         node.community.get_node("test", nodes, 3, 5, 1))
 
     def test_get_node_request_total_traffic(self):
         """
         Check whether get_node requires a total_traffic method if no total_up and total_down is given.
         """
         node, = self.create_nodes(1)
-        node.community.persistence.total_traffic = lambda _: [5, 6]
-        self.assertEqual({"public_key": '74657374', "total_up": 5, "total_down": 6},
+        node.community.persistence.total_traffic = lambda _: [5, 6, 2]
+        self.assertEqual({"public_key": '74657374', "total_up": 5, "total_down": 6, "total_neighbors": 2},
                          node.community.get_node('74657374', []))
 
     def test_update_edges_empty(self):

--- a/Tribler/Test/Community/Triblerchain/test_database.py
+++ b/Tribler/Test/Community/Triblerchain/test_database.py
@@ -104,19 +104,22 @@ class TestDatabase(TrustChainTestCase):
         self.db.insert_aggregate_block(self.block2)
         self.db.insert_aggregate_block(self.block3)
 
-        pk_1_up, pk_1_down = self.db.total_traffic("11")
-        pk_f_up, pk_f_down = self.db.total_traffic("ff")
-        fake_up, fake_down = self.db.total_traffic("aa")
+        pk_1_up, pk_1_down, pk_1_neigh = self.db.total_traffic("11")
+        pk_f_up, pk_f_down, pk_f_neigh = self.db.total_traffic("ff")
+        fake_up, fake_down, fake_neigh = self.db.total_traffic("aa")
 
         # Multiple links
         self.assertEqual(self.block1.transaction["down"] + self.block2.transaction["up"], pk_1_up)
         self.assertEqual(self.block1.transaction["up"] + self.block2.transaction["down"], pk_1_down)
+        self.assertEqual(2, pk_1_neigh)
         # One link
         self.assertEqual(self.block3.transaction["up"], pk_f_up)
         self.assertEqual(self.block3.transaction["down"], pk_f_down)
+        self.assertEqual(1, pk_f_neigh)
         # No links
         self.assertEqual(0, fake_up)
         self.assertEqual(0, fake_down)
+        self.assertEqual(0, fake_neigh)
 
     @blocking_call_on_reactor_thread
     def test_neighbors(self):

--- a/Tribler/Test/Core/Modules/RestApi/test_trustchain_network_endpoint.py
+++ b/Tribler/Test/Core/Modules/RestApi/test_trustchain_network_endpoint.py
@@ -114,10 +114,11 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         exp_message = {"user_node": user_public_key,
                        "focus_node": user_public_key,
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5}],
+                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5,
+                                  "total_neighbors": 0}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("trustchain", "self", 1)
-        self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
+        self.assertDictEqual(exp_message, loads(network_endpoint.render_GET(request)))
 
     def test_negative_neighbor_level(self):
         """
@@ -127,10 +128,11 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         exp_message = {"user_node": user_public_key,
                        "focus_node": hexlify(self.member.public_key),
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5}],
+                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5,
+                                  "total_neighbors": 0}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("trustchain", "self", -1)
-        self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
+        self.assertDictEqual(exp_message, loads(network_endpoint.render_GET(request)))
 
     def test_empty_dataset(self):
         """
@@ -140,17 +142,19 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
         exp_message = {"user_node": user_public_key,
                        "focus_node": user_public_key,
                        "neighbor_level": 1,
-                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5}],
+                       "nodes": [{"public_key": user_public_key, "total_up": 0, "total_down": 0, "score": 0.5,
+                                  "total_neighbors": 0}],
                        "edges": []}
         network_endpoint, request = self.set_up_endpoint_request("", "self", 1)
-        self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
+        self.assertDictEqual(exp_message, loads(network_endpoint.render_GET(request)))
 
     def test_no_dataset(self):
         """
         Evaluate whether the API sends a response when the dataset is not defined.
         """
         user_public_key = hexlify(self.member.public_key)
-        exp_message = {"nodes": [{"public_key": user_public_key, "total_down": 0, "total_up": 0, "score": 0.5}],
+        exp_message = {"nodes": [{"public_key": user_public_key, "total_down": 0, "total_up": 0, "score": 0.5,
+                                  "total_neighbors": 0}],
                        "neighbor_level": 1,
                        "user_node": user_public_key,
                        "focus_node": user_public_key,
@@ -158,7 +162,7 @@ class TestTrustchainNetworkEndpoint(AbstractApiTest):
 
         network_endpoint, request = self.set_up_endpoint_request("", "self", 1)
         del request.args["dataset"]
-        self.assertEquals(dumps(exp_message), network_endpoint.render_GET(request))
+        self.assertDictEqual(exp_message, loads(network_endpoint.render_GET(request)))
 
     @blocking_call_on_reactor_thread
     def test_static_dataset(self):

--- a/Tribler/community/triblerchain/community.py
+++ b/Tribler/community/triblerchain/community.py
@@ -166,7 +166,7 @@ class TriblerChainCommunity(TrustChainCommunity):
                 self.pending_bytes[pk].clean.reset(0)
         yield super(TriblerChainCommunity, self).unload_community()
 
-    def get_node(self, public_key, nodes, total_up=None, total_down=None):
+    def get_node(self, public_key, nodes, total_up=None, total_down=None, total_neighbors=None):
         """
         Get a node in an encoded format and with the maximum values given the current dictionary of nodes.
 
@@ -184,13 +184,16 @@ class TriblerChainCommunity(TrustChainCommunity):
         """
         if public_key in nodes:
             return {"public_key": public_key, "total_up": max(total_up, nodes[public_key]["total_up"]),
-                    "total_down": max(total_down, nodes[public_key]["total_down"])}
+                    "total_down": max(total_down, nodes[public_key]["total_down"]),
+                    "total_neighbors": max(total_neighbors, nodes[public_key]["total_neighbors"])}
         else:
-            if total_up and total_down:
-                return {"public_key": public_key, "total_up": total_up, "total_down": total_down}
+            if total_up and total_down and total_neighbors:
+                return {"public_key": public_key, "total_up": total_up, "total_down": total_down,
+                        "total_neighbors": total_neighbors}
             else:
                 total_traffic = self.persistence.total_traffic(public_key)
-                return {"public_key": public_key, "total_up": total_traffic[0], "total_down": total_traffic[1]}
+                return {"public_key": public_key, "total_up": total_traffic[0], "total_down": total_traffic[1],
+                        "total_neighbors": total_traffic[2]}
 
     @staticmethod
     def update_edges(from_pk, to_pk, edges, amount=0):
@@ -231,7 +234,8 @@ class TriblerChainCommunity(TrustChainCommunity):
             to_pk = str(edge[1])
             amount_up = edge[2]
             amount_down = edge[3]
-            nodes[from_pk] = self.get_node(from_pk, nodes, total_up=edge[4], total_down=edge[5])
+            nodes[from_pk] = self.get_node(from_pk, nodes, total_up=edge[4], total_down=edge[5],
+                                           total_neighbors=edge[6])
             nodes[to_pk] = self.get_node(to_pk, nodes)
             self.update_edges(from_pk, to_pk, edges, amount=amount_up)
             self.update_edges(to_pk, from_pk, edges, amount=amount_down)

--- a/TriblerGUI/test/widgets/network_explorer/js/test_data_processor.js
+++ b/TriblerGUI/test/widgets/network_explorer/js/test_data_processor.js
@@ -53,7 +53,8 @@ describe('data_processor.js', function () {
                 public_key: 'aaa',
                 total_up: 5,
                 total_down: 10,
-                score: 0.5
+                score: 0.5,
+                total_neighbors: 1
             }]);
         });
     });
@@ -299,9 +300,9 @@ describe('data_processor.js', function () {
 
     function getTestData() {
         return {
-            node1: {public_key: 'aaa', total_up: 5, total_down: 10, score: 0.5},
-            node2: {public_key: 'bbb', total_up: 110, total_down: 50, score: 0.3},
-            node3: {public_key: 'ccc', total_up: 40, total_down: 50, score: 0.2},
+            node1: {public_key: 'aaa', total_up: 5, total_down: 10, score: 0.5, total_neighbors: 1},
+            node2: {public_key: 'bbb', total_up: 110, total_down: 50, score: 0.3, total_neighbors: 1},
+            node3: {public_key: 'ccc', total_up: 40, total_down: 50, score: 0.2, total_neighbors: 0},
             edge1to2: {from: "aaa", to: "bbb", amount: 4},
             edge2to1: {from: "bbb", to: "aaa", amount: 16},
             edge1to3: {from: "aaa", to: "bbb", amount: 5}

--- a/TriblerGUI/widgets/network_explorer/js/data_processor.js
+++ b/TriblerGUI/widgets/network_explorer/js/data_processor.js
@@ -29,7 +29,7 @@ function processData(response) {
         focusNodePublicKey,
         sortNodes,
         makeLocalKeyMap, // after sorting
-        addNeighborsToNodes,
+        addNeighborsToNodes
     ];
 
     return convertResponse(response, converters);
@@ -64,7 +64,8 @@ function mapNodes(response) {
             public_key: node.public_key,
             total_up: node.total_up,
             total_down: node.total_down,
-            score: node.score
+            score: node.score,
+            total_neighbors: node.total_neighbors
         }
     });
 
@@ -340,13 +341,14 @@ function groupBy(list, key) {
 
 /**
  * @typedef {Object} GraphNode
- * @property {String} public_key     - the public key of this node
- * @property {number} local_key      - the local key of this node (corresponds with GraphData.local_keys)
- * @property {number} total_up       - the total upload by this node
- * @property {number} total_down     - the total download by this node
- * @property {number} score          - the score between 0 and 1 for the rating in the network of the node
- * @property {boolean} is_user       - true if this node represents the user
- * @property {GraphNode[]} neighbors - the list of neighbors of this node
+ * @property {String} public_key      - the public key of this node
+ * @property {number} local_key       - the local key of this node (corresponds with GraphData.local_keys)
+ * @property {number} total_up        - the total upload by this node
+ * @property {number} total_down      - the total download by this node
+ * @property {number} score           - the score between 0 and 1 for the rating in the network of the node
+ * @property {number} total_neighbors - The number of neighbors the node has
+ * @property {boolean} is_user        - true if this node represents the user
+ * @property {GraphNode[]} neighbors  - the list of neighbors of this node
  */
 
 /**

--- a/TriblerGUI/widgets/network_explorer/js/radial_view/radial_inspector.js
+++ b/TriblerGUI/widgets/network_explorer/js/radial_view/radial_inspector.js
@@ -68,7 +68,9 @@ function RadialInspector(d3element, options) {
                 formatted_upload: formatBytes(node.total_up),
                 formatted_download: formatBytes(node.total_down),
                 formatted_balance: (balance > 0 ? "+" : "") + formatBytes(balance),
-                peer_count: node.neighbors.length,
+                peer_count: node.total_neighbors,
+                shown_peer_count: node.neighbors.length,
+                x: self._getNodeIdentifier(node),
                 color: radial_nodes._calculateFill(node)
             };
             bindings.user = "user" + (bindings.peer_count === 1 ? "" : "s");
@@ -77,8 +79,9 @@ function RadialInspector(d3element, options) {
             self._getNodeIdentifier(node),
             "Anonymous",
             [
-                "Shared <strong>{formatted_upload}</strong> with {peer_count} {user}",
-                "Consumed <strong>{formatted_download}</strong> from {peer_count} {user}",
+                "Shared <strong>{formatted_upload}</strong>",
+                "Consumed <strong>{formatted_download}</strong>",
+                "Showing {shown_peer_count} of {peer_count} connected {user}.",
                 "<span class='badge' style='background:{color}'>Balance: <strong>{formatted_balance}</strong></span>"
             ], bindings);
     };

--- a/TriblerGUI/widgets/network_explorer/js/request_data.js
+++ b/TriblerGUI/widgets/network_explorer/js/request_data.js
@@ -34,6 +34,8 @@ function make_cors_request(method, url) {
  *           "public_key": "xyz",
  *           "total_up": 12736457,
  *           "total_down": 1827364,
+ *           "score": 0.0011,
+ *           "total_neighbors": 1
  *       }, ...],
  *       "edges": [{
  *           "from": "xyz",
@@ -92,5 +94,6 @@ function get_node_info(public_key, neighbor_level, callback) {
  * @property {String} public_key - The public key of the node
  * @property {number} total_up   - The total amount of MB uploaded by the node
  * @property {number} total_down - The total amount of MB downloaded by the node
- * @property {number} score      - the score between 0 and 1 for the rating in the network of the node
+ * @property {number} score      - The score between 0 and 1 for the rating in the network of the node
+ * @property {number} total_neighbors  - The number of neighbors the node has
  */


### PR DESCRIPTION
In this PR, the total neighbors is requested throughout the whole
pipeline, after which it is displayed in the frontend, along with the
shown nodes in the current point of view.

Fixes #336 